### PR TITLE
TAC: Update resize() in torch_utils to support channels-last inputs b…

### DIFF
--- a/lunar_tools/torch_utils.py
+++ b/lunar_tools/torch_utils.py
@@ -270,6 +270,10 @@ def resize(input_img, resizing_factor=None, size=None, resample_method='bicubic'
     elif input_type == torch.Tensor:
         input_dtype = input_img.dtype
         input_tensor = input_img.clone().to(dtype=torch.float, device=device)
+        is_channels_last = False
+        if input_tensor.dim() == 3 and input_tensor.shape[2] == 3:
+            is_channels_last = True
+            input_tensor = input_tensor.permute(2, 0, 1)
     else:
         raise TypeError("input_img should be of type np.ndarray, PIL.Image, or torch.Tensor")
     
@@ -302,6 +306,8 @@ def resize(input_img, resizing_factor=None, size=None, resample_method='bicubic'
         resized_array = np.clip(np.round(resized_tensor.numpy()), 0, 255).astype('uint8')
         return Image.fromarray(resized_array, 'RGB')
     else:
+        if 'is_channels_last' in locals() and is_channels_last:
+            resized_tensor = resized_tensor.permute(1,2,0)
         return resized_tensor.to(input_dtype)
     
 class FrequencyFilter:

--- a/tests/test_torch_utils.py
+++ b/tests/test_torch_utils.py
@@ -13,3 +13,15 @@ def test_resize_batch_image_error():
     input_tensor = torch.rand(1, 3, 100, 200)
     with pytest.raises(ValueError, match="resize\\(\\) does not support batched images; expected a 3-dimensional tensor."):
         resize(input_tensor, resizing_factor=2)
+
+def test_resize_channels_last():
+    # Create a channels-last tensor (H, W, C)
+    img = torch.rand(100, 150, 3)
+    output = resize(img, size=(200, 300))
+    assert output.shape == (200, 300, 3), f"Expected shape (200, 300, 3) but got {output.shape}"
+
+def test_resize_channels_first():
+    # Create a channels-first tensor (C, H, W)
+    img = torch.rand(3, 100, 150)
+    output = resize(img, size=(200, 300))
+    assert output.shape == (3, 200, 300), f"Expected shape (3, 200, 300) but got {output.shape}"


### PR DESCRIPTION
…y permuting dimensions before and after resizing.